### PR TITLE
Update agentinstall.ps1

### DIFF
--- a/install/agentinstall.ps1
+++ b/install/agentinstall.ps1
@@ -1,3 +1,6 @@
+#Requires -PSEdition Desktop
+#Requires -RunAsAdministrator
+
 param(
   [switch] $help = $false,
   [switch] $windows_event_log = $false,


### PR DESCRIPTION
Current version of installer works with PowerShell 5.1 and fails with PowerShell 6.0+. It is safe to explicitly specify the edition until it is fixed.